### PR TITLE
Filter wheel

### DIFF
--- a/MyASICap.pro
+++ b/MyASICap.pro
@@ -26,6 +26,7 @@ CONFIG += c++11
 
 SOURCES += \
         asicamera.cpp \
+        filterwheel.cpp \
         focuser.cpp \
         image.cpp \
         main.cpp \
@@ -35,6 +36,7 @@ SOURCES += \
 HEADERS += \
         asicamera.h \
         camera.h \
+        filterwheel.h \
         focuser.h \
         image.h \
         mainframe.h \
@@ -43,7 +45,7 @@ HEADERS += \
 FORMS += \
         mainframe.ui
 
-LIBS += -lASICamera2
+LIBS += -lASICamera2 -lEFW_filter
 
 unix:INCLUDEPATH += /usr/include/libasi
 

--- a/MyASICap.pro
+++ b/MyASICap.pro
@@ -45,15 +45,17 @@ HEADERS += \
 FORMS += \
         mainframe.ui
 
-LIBS += -lASICamera2 -lEFW_filter
-
-unix:INCLUDEPATH += /usr/include/libasi
-
-win32:contains(QMAKE_HOST.arch, x86_64) {
+win32: {
     INCLUDEPATH += "..\ASI SDK\include"
+    LIBS += -lASICamera2 -lEFW_filter
+} else: unix: {
+    INCLUDEPATH += /usr/include/libasi
+    LIBS += -lASICamera2 -lEFWFilter
+}
+
+win32:contains(QMAKE_HOST.arch, x86_64) {  
     LIBS += -L"..\ASI SDK\lib\x64"
 } else {
-    INCLUDEPATH += "..\ASI SDK\include"
     LIBS += -L"..\ASI SDK\lib\x86"
 }
 

--- a/filterwheel.cpp
+++ b/filterwheel.cpp
@@ -1,0 +1,79 @@
+#include "filterwheel.h"
+
+#include "EFW_filter.h"
+
+#include <QDebug>
+
+class EFWException : public std::exception {
+public:
+    EFWException( EFW_ERROR_CODE _errorCode ) :
+        errorCode( _errorCode )
+    {
+    }
+
+    const char* what() const noexcept override
+    {
+        switch( errorCode ) {
+            case EFW_ERROR_INVALID_INDEX: return "Invalid index";
+            case EFW_ERROR_INVALID_ID: return "Invalid id";
+            case EFW_ERROR_INVALID_VALUE: return "Invalid value";
+            case EFW_ERROR_REMOVED: return "Filter wheel removed";
+            case EFW_ERROR_MOVING: return "Filter wheel moving";
+            case EFW_ERROR_ERROR_STATE: return "Filter wheel error state";
+            case EFW_ERROR_GENERAL_ERROR: return "Filter wheel general error";
+            case EFW_ERROR_NOT_SUPPORTED: return "Filter wheel operation not supported";
+            case EFW_ERROR_CLOSED: return "Filter wheel closed";
+            default:
+                return 0;
+        }
+    }
+
+private:
+    EFW_ERROR_CODE errorCode;
+};
+
+static void checkResult( EFW_ERROR_CODE errorCode )
+{
+    if( errorCode != EFW_SUCCESS ) {
+        throw EFWException( errorCode );
+    }
+}
+
+bool FilterWheel::Open()
+{
+    int count = EFWGetNum();
+    if( count > 0 ) {
+        checkResult( EFWGetID( 0, &id ) );
+        checkResult( EFWOpen( id ) );
+        EFW_INFO info;
+        checkResult( EFWGetProperty( id, &info ) );
+        slotsCount = info.slotNum;
+        return true;
+    }
+    return false;
+}
+
+int FilterWheel::GetPosition()
+{
+    if( slotsCount > 0 ) {
+        int pos = -1;
+        checkResult( EFWGetPosition( id, &pos ) );
+        return pos;
+    }
+    return -1;
+}
+
+void FilterWheel::SetPosition( int pos )
+{
+    if( pos < slotsCount ) {
+        checkResult( EFWSetPosition( id, pos ) );
+    }
+}
+
+void FilterWheel::Close()
+{
+    if( slotsCount > 0 ) {
+        checkResult( EFWClose( id ) );
+        slotsCount = 0;
+    }
+}

--- a/filterwheel.h
+++ b/filterwheel.h
@@ -1,0 +1,19 @@
+#ifndef FILTERWHEEL_H
+#define FILTERWHEEL_H
+
+class FilterWheel {
+public:
+    bool Open();
+    void Close();
+
+    int GetSlotsCount() const { return slotsCount; };
+
+    int GetPosition();
+    void SetPosition( int );
+
+private:
+    int id;
+    int slotsCount = 0;
+};
+
+#endif // FILTERWHEEL_H

--- a/mainframe.cpp
+++ b/mainframe.cpp
@@ -97,6 +97,10 @@ MainFrame::MainFrame( QWidget *parent ) :
    }
 
    if( filterWheel.Open() ) {
+       // TODO: Fixing a bug with text color on Raspberry Pi (old Qt?). It shows always gray
+       // To fix it needs changing the combo to editable and the edit inside the combo to read-only
+       ui->filterComboBox->lineEdit()->setReadOnly( true );
+
        for( size_t i = 0; i < filterWheel.GetSlotsCount(); i++ ) {
            ui->filterComboBox->addItem( QString::number( i + 1 ) );
        }

--- a/mainframe.cpp
+++ b/mainframe.cpp
@@ -96,6 +96,14 @@ MainFrame::MainFrame( QWidget *parent ) :
        );
    }
 
+   if( filterWheel.Open() ) {
+       for( size_t i = 0; i < filterWheel.GetSlotsCount(); i++ ) {
+           ui->filterComboBox->addItem( QString::number( i + 1 ) );
+       }
+       ui->filterComboBox->setCurrentIndex( filterWheel.GetPosition() );
+       connect( ui->filterComboBox, QOverload<int>::of( &QComboBox::currentIndexChanged ), [this]( int index ) { filterWheel.SetPosition( index ); } );
+   }
+
    updateUI();
 }
 
@@ -105,6 +113,7 @@ MainFrame::~MainFrame()
         closeCamera();
     }
     focuser.Close();
+    filterWheel.Close();
     delete ui;
 }
 
@@ -115,6 +124,7 @@ void MainFrame::updateUI()
     ui->captureFrame->setVisible( camera != 0 );
     ui->temperatureFrame->setVisible( camera != 0 && camera->HasCooler() );
     ui->cameraOpenCloseButton->setText( camera != 0 ? "X" : ">" );
+    ui->filterWheelFrame->setVisible( filterWheel.GetSlotsCount() > 0 );
 }
 
 void MainFrame::on_closeButton_clicked()

--- a/mainframe.h
+++ b/mainframe.h
@@ -12,6 +12,7 @@
 
 #include "camera.h"
 #include "focuser.h"
+#include "filterwheel.h"
 
 namespace Ui {
     class MainFrame;
@@ -87,6 +88,7 @@ private:
 
     // Focuser
     Focuser focuser;
+    FilterWheel filterWheel;
 
     // Rendering
     ulong render( const ushort* raw, int width, int height );

--- a/mainframe.ui
+++ b/mainframe.ui
@@ -617,6 +617,55 @@ QSlider::handle:horizontal {
            </widget>
           </item>
           <item>
+           <widget class="QFrame" name="filterWheelFrame">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::StyledPanel</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_7">
+             <property name="spacing">
+              <number>3</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="filterLabel">
+               <property name="layoutDirection">
+                <enum>Qt::LeftToRight</enum>
+               </property>
+               <property name="text">
+                <string>Filter:</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="filterComboBox"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
            <widget class="QFrame" name="temperatureFrame">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/mainframe.ui
+++ b/mainframe.ui
@@ -660,7 +660,11 @@ QSlider::handle:horizontal {
               </widget>
              </item>
              <item>
-              <widget class="QComboBox" name="filterComboBox"/>
+              <widget class="QComboBox" name="filterComboBox">
+               <property name="editable">
+                <bool>true</bool>
+               </property>
+              </widget>
              </item>
             </layout>
            </widget>


### PR DESCRIPTION
Basic filter wheel support (ZWO EFW, tested both on Windows and on Raspberry Pi).
On Raspberry Pi had to add a line to **/lib/udev/rules.d/99-asi.rules** as follows:
`KERNEL=="hidraw*", ATTRS{idVendor}=="03c3", ATTRS{idProduct}=="1f01", MODE="0666"`
